### PR TITLE
Hyperref warnings

### DIFF
--- a/fr/annexes/index.tex
+++ b/fr/annexes/index.tex
@@ -1,5 +1,9 @@
 \chapter{Index}
 
+\makeatletter
+\let\imki@name\jobname
+\makeatother
+
 \indexprologue{Ne sont pas référencées les commandes situées dans les exemples colorés. En règle générale ces commandes sont expliquées avant ou après ces exemples.
 
 Les entrées en gras renvoient à la définition de la commande.}

--- a/fr/avancees/entetepied.tex
+++ b/fr/avancees/entetepied.tex
@@ -132,7 +132,7 @@ Avec ceci, nous obtenons à nouveau le titre de chapitre à gauche et le titre d
 Les en-têtes et pieds de pages sont calculés par \LaTeX \emph{après} le reste de la page. C'est pourquoi on obtient dans l'en-tête le contenu de la dernière section de la page.
 \end{attention}
 
-\subsection[Redéfinir \oldcs{chaptermark} et \oldcs{sectionmark}]{Redéfinir les commandes \cs{chaptermark} et \cs{sectionmark}}
+\subsection[Redéfinir \texorpdfstring{\oldcs{chaptermark}}{chaptermark} et \texorpdfstring{\oldcs{sectionmark}}{sectionmark}]{Redéfinir les commandes \cs{chaptermark} et \cs{sectionmark}}
 
 Supposons désormais que vous ne souhaitez plus voir les titres des sections dans les en-têtes. Le plus simple est alors de redéfinir la commande \cs{sectionmark}, pour la rendre nulle :
 

--- a/fr/biblio/citation.tex
+++ b/fr/biblio/citation.tex
@@ -10,7 +10,7 @@ Il ne nous reste plus qu'à mettre en relation les textes cités avec la base de
 \end{intro}
 
 
-\section[Appel du package]{Appel du package \package{biblatex}}
+\section[Appel du package biblatex]{Appel du package \texorpdfstring{\package{biblatex}}{biblatex}}
 
 La gestion bibliographique s'effectue avec le package \package{biblatex}. Dans le préambule, on appelle le package dans sa forme la plus simple par la commande:
 \cs{usepackage}\verb|{biblatex}|.

--- a/fr/biblio/style2.tex
+++ b/fr/biblio/style2.tex
@@ -8,8 +8,7 @@
 \end{intro}
 
 
-
-\section[Que se passe-t-il lorsqu'on utilise \oldcs{\meta{prefix}cite}]{Que se passe-t-il lorsqu'on utilise une commande \cs{\meta{prefix}cite} ?}
+\section[Que se passe-t-il lorsqu'on utilise \texorpdfstring{\oldcs{\meta{prefix}cite}}{\textbackslash <prefix>cite}]{Que se passe-t-il lorsqu'on utilise une commande \cs{\meta{prefix}cite} ?}
 
 Pour comprendre comment personnaliser l'affichage bibliographique, il est nécessaire de connaître sommairement ce qui se passe lorsqu'on utilise une commande de citation. 
 

--- a/fr/navigation/renvoi.tex
+++ b/fr/navigation/renvoi.tex
@@ -5,7 +5,7 @@ Dans ce court chapitre nous allons nous intéresser à la manière de faire des 
 Il s'agit de permettre d'afficher des textes du type : \enquote{Nous renvoyons au chapitre~N. page~P.}
 \end{intro}
 
-\section{Étiqueter des  emplacements : \cs{label}}
+\section{Étiqueter des  emplacements : \texorpdfstring{\cs{label}}{\textbackslash label}}
 
 Pour pouvoir faire des renvois internes, il est nécessaire de placer des \enquote{étiquettes} aux endroits vers lesquels on souhaite renvoyer.
 Cet étiquetage  se fait avec la commande \csp{label}\marg{etiquette}.
@@ -67,7 +67,7 @@ Nous renvoyons à la section  \enquote{\nameref{etiquette}}.
 Toutefois cette commande n'est pas disponible en standard : elle est proposée par le package \package{hyperref}. Il faut donc charger ce package dans le préambule. Nous documentons plus loin quelques fonctionnalités de ce package\renvoi{hyperref}.
 
 
-\section[Où placer la commande \oldcs{label} ?]{Où placer la commande \cs{label} ?}
+\section[Où placer la commande \texorpdfstring{\oldcs{label}}{\textbackslash label} ?]{Où placer la commande \cs{label} ?}
 
 Pour le moment, nous n'avons vu que des renvois vers des sections, mais le système de renvois est beaucoup plus souple.
 

--- a/fr/preambule/documentation.tex
+++ b/fr/preambule/documentation.tex
@@ -46,7 +46,7 @@
   {\ttfamily(}\meta{#1}{\ttfamily)}}
 
 \renewcommand{\arg}[1]{%
-	\meta{#1}%
+	\texorpdfstring{\meta{#1}}{#1}%
 }
 \newcommand{\contenuarg}[1]{\mbox{{\ttfamily#1}}}
 

--- a/fr/preambule/index.tex
+++ b/fr/preambule/index.tex
@@ -1,4 +1,5 @@
 \indexsetup{level=\section,noclearpage}
+\makeindex
 \makeindex[title=Commandes,name=cs]
 \makeindex[title=Classes,name=classe]
 \makeindex[title=Champs bibliographiques,name=champ]

--- a/fr/premierpas/commande.tex
+++ b/fr/premierpas/commande.tex
@@ -156,7 +156,7 @@ n'était pas montaniste mais tertullianiste.
 Il n'y a plus d'espaces intempestives.
 
 
-\subsection{Étoiler \oldcs{newcommand}}
+\subsection{Étoiler \texorpdfstring{\oldcs{newcommand}}{newcommand}}
 
 La création des commandes sous \LaTeX est une fonctionnalité très puissante, mais potentiellement dangereuse. Prenons la commande suivante :
 


### PR DESCRIPTION
I had two problems with index creation:
1. the main idx file wasn't written
2. printindex used the wrong base filename (This is a work around, not a bug fix.)

I added texorpdfstring to some definitions and sectioning commands to remove hyperref warnings and create clean TOC entries in the pdf.

Axel